### PR TITLE
Add math expressions when adding karma

### DIFF
--- a/karma_cli/PKGBUILD
+++ b/karma_cli/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: ftsell <aur@finn-thorben.me>
 pkgname=bitbots-karma-cli-git
-pkgver=r67.2a00d7b
+pkgver=r93.9ac8e20
 pkgrel=1
 _gitname=karma
 _gitbranch=master
@@ -9,7 +9,7 @@ arch=(any)
 url="https://github.com/bit-bots/${_gitname}"
 license=("MIT")
 makedepends=("git")
-depends=("python" "python-yaml" "python-requests")
+depends=("python" "python-yaml" "python-requests" "python-numexpr")
 source=("${_gitname}::git+https://github.com/bit-bots/${_gitname}.git#branch=${_gitbranch}")
 sha256sums=("SKIP")
 

--- a/karma_cli/debian_build.sh
+++ b/karma_cli/debian_build.sh
@@ -16,7 +16,7 @@ Version: $VERSION-$REVISION
 Section: misc
 Priority: optional
 Architecture: all
-Depends: python3, python3-yaml, python3-requests
+Depends: python3, python3-yaml, python3-requests, python3-numexpr
 Maintainer: Timon Engelke <debian@timonengelke.de>
 Homepage: https://karma.bit-bots.de
 Vcs-Browser: https://github.com/bit-bots/karma

--- a/karma_cli/debian_build.sh
+++ b/karma_cli/debian_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION=1.0.2
+VERSION=1.1.0
 REVISION=1
 
 BUILD_DIR=$(mktemp -d)

--- a/karma_cli/src/karma_cli.py
+++ b/karma_cli/src/karma_cli.py
@@ -6,6 +6,7 @@ import yaml
 import getpass
 import os
 import requests
+import numexpr
 
 
 class COLORS:
@@ -28,7 +29,7 @@ parser = argparse.ArgumentParser(description="Command Line Interface for 'Karma 
 subparsers = parser.add_subparsers(title="command", description="command which shall be performed", dest="command")
 
 parser_add = subparsers.add_parser("add", help="add karma to your account")
-parser_add.add_argument("points", type=int, help="number of karma points to add")
+parser_add.add_argument("points", type=str, help="number of karma points to add")
 parser_add.add_argument("-p", "--project", default="", dest="project", help="project to which karma is added",
                         required=False)
 parser_add.add_argument("-c", "--category", default="", dest="category", help="category to which karma is added",
@@ -63,6 +64,10 @@ parser_hs.add_argument("-p", "--project", nargs="?", default="", dest="project",
                        required=False)
 parser_hs.add_argument("-s", "--sum", dest="sum", action="store_true")
 args = parser.parse_args()
+
+if args.points:
+    args.points = int(numexpr.evaluate(args.points))
+
 if not args.command:
     # Highscore of 14 days (used for weekly) is default action
     args.command = "highscore"

--- a/karma_cli/src/karma_cli.py
+++ b/karma_cli/src/karma_cli.py
@@ -7,6 +7,7 @@ import getpass
 import os
 import requests
 import numexpr
+from sys import exit
 
 
 class COLORS:

--- a/karma_cli/src/karma_cli.py
+++ b/karma_cli/src/karma_cli.py
@@ -66,7 +66,11 @@ parser_hs.add_argument("-s", "--sum", dest="sum", action="store_true")
 args = parser.parse_args()
 
 if args.points:
-    args.points = int(numexpr.evaluate(args.points))
+    try:
+        args.points = int(numexpr.evaluate(args.points))
+    except: 
+        print(f"{COLORS.FAIL}Invalid math expression!{COLORS.ENDC}")
+        exit(1)
 
 if not args.command:
     # Highscore of 14 days (used for weekly) is default action

--- a/karma_cli/src/karma_cli.py
+++ b/karma_cli/src/karma_cli.py
@@ -68,6 +68,7 @@ if not args.command:
     args.command = "highscore"
     args.days = 14
     args.project = ''
+    args.sum = False
 
 base_url = "https://karma.bit-bots.de/api/"
 


### PR DESCRIPTION
You are now able to use expressions like this in the karma cli:
```
karma add "(18-16)*60"
```

It also replaces `exit()` from the python interactive shell with `sys.exit()` that is intended for programs.